### PR TITLE
Add spells list page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,8 @@ import MJPage from './pages/MJ';
 import GamePage from './pages/Game';
 import CharacterPage from './pages/Character';
 import CreateCharacter from './pages/CreateCharacter';
+import CreateResources from './pages/CreateResources';
+import Spells from './pages/Spells';
 
 export default function App() {
   return (
@@ -18,6 +20,8 @@ export default function App() {
         <Route path="/game" element={<GamePage />} />
         <Route path="/character/:id" element={<CharacterPage />} />
         <Route path="/create-character" element={<CreateCharacter />} />
+        <Route path="/spells" element={<Spells />} />
+        <Route path="/create-resources" element={<CreateResources />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Router>

--- a/src/pages/CreateResources.jsx
+++ b/src/pages/CreateResources.jsx
@@ -1,0 +1,212 @@
+// src/pages/CreateResources.jsx
+// TODO: future page for NPC management and player edits
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+
+const DEBUG = import.meta.env.VITE_DEBUG === 'true';
+const dbg = (...args) => DEBUG && console.debug('[CreateResources]', ...args);
+const info = (...args) => console.info('[CreateResources]', ...args);
+const warn = (...args) => console.warn('[CreateResources]', ...args);
+const err = (...args) => console.error('[CreateResources]', ...args);
+
+export default function CreateResources() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [spellName, setSpellName] = useState('');
+  const [spellDesc, setSpellDesc] = useState('');
+  const [spellLevel, setSpellLevel] = useState('');
+  const [spellSchool, setSpellSchool] = useState('');
+  const [spellCost, setSpellCost] = useState('');
+  const [spellCastTime, setSpellCastTime] = useState('');
+  const [spellRange, setSpellRange] = useState('');
+  const [spellDuration, setSpellDuration] = useState('');
+  const [spells, setSpells] = useState([]);
+  const [bookTitle, setBookTitle] = useState('');
+  const [bookAuthor, setBookAuthor] = useState('');
+
+  const loadSpells = async () => {
+    info('Chargement des sorts');
+    const { data, error } = await supabase
+      .from('spells')
+      .select('*')
+      .order('name');
+    if (error) {
+      err('fetch spells', error);
+    } else {
+      setSpells(data || []);
+    }
+  };
+
+  useEffect(() => {
+    dbg('Checking session for CreateResources page');
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.user) {
+        info('Pas de session, redirection /');
+        return navigate('/', { replace: true });
+      }
+      info('Session ok, vérification rôle MJ');
+      supabase
+        .from('profiles')
+        .select('is_mj')
+        .eq('id', session.user.id)
+        .single()
+        .then(({ data }) => {
+          if (!data?.is_mj) {
+            warn('Utilisateur non MJ, redirection /');
+            navigate('/', { replace: true });
+          } else {
+            dbg('Accès MJ autorisé pour ressources');
+            loadSpells();
+            setLoading(false);
+          }
+        })
+        .catch((e) => {
+          err('Erreur fetch profil', e);
+          navigate('/', { replace: true });
+        });
+    });
+  }, [navigate]);
+
+  const createSpell = async (e) => {
+    e.preventDefault();
+    info('Création sort', spellName);
+    const { error } = await supabase
+      .from('spells')
+      .insert({
+        name: spellName,
+        description: spellDesc,
+        level: spellLevel,
+        school: spellSchool,
+        cost: spellCost,
+        cast_time: spellCastTime,
+        range: spellRange,
+        duration: spellDuration,
+      });
+    if (error) {
+      err('insert spell', error);
+    } else {
+      setSpellName('');
+      setSpellDesc('');
+      setSpellLevel('');
+      setSpellSchool('');
+      setSpellCost('');
+      setSpellCastTime('');
+      setSpellRange('');
+      setSpellDuration('');
+      loadSpells();
+    }
+  };
+
+  const createBook = async (e) => {
+    e.preventDefault();
+    info('Création livre', bookTitle);
+    const { error } = await supabase
+      .from('books')
+      .insert({ title: bookTitle, author: bookAuthor });
+    if (error) {
+      err('insert book', error);
+    } else {
+      setBookTitle('');
+      setBookAuthor('');
+    }
+  };
+
+  if (loading) {
+    return <p>Chargement...</p>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Gestion des ressources</h1>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Créer un sort</h2>
+        <form onSubmit={createSpell} className="space-y-2">
+          <input
+            className="w-full p-2 rounded bg-gray-800"
+            value={spellName}
+            onChange={(e) => setSpellName(e.target.value)}
+            placeholder="Nom du sort"
+          />
+          <textarea
+            className="w-full p-2 rounded bg-gray-800"
+            value={spellDesc}
+            onChange={(e) => setSpellDesc(e.target.value)}
+            placeholder="Description"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellLevel}
+              onChange={(e) => setSpellLevel(e.target.value)}
+              placeholder="Niveau"
+            />
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellSchool}
+              onChange={(e) => setSpellSchool(e.target.value)}
+              placeholder="École"
+            />
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellCost}
+              onChange={(e) => setSpellCost(e.target.value)}
+              placeholder="Coût/Mana"
+            />
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellCastTime}
+              onChange={(e) => setSpellCastTime(e.target.value)}
+              placeholder="Temps d'incantation"
+            />
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellRange}
+              onChange={(e) => setSpellRange(e.target.value)}
+              placeholder="Portée"
+            />
+            <input
+              className="w-full p-2 rounded bg-gray-800"
+              value={spellDuration}
+              onChange={(e) => setSpellDuration(e.target.value)}
+              placeholder="Durée"
+            />
+          </div>
+          <button className="px-4 py-2 bg-green-600 rounded" type="submit">
+            Sauvegarder le sort
+          </button>
+        </form>
+        <h3 className="text-lg font-semibold mt-4">Sorts existants</h3>
+        <ul className="mt-2 space-y-1">
+          {spells.map((s) => (
+            <li key={s.id} className="bg-gray-800 p-2 rounded">
+              <span className="font-medium">{s.name}</span> – niveau {s.level}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Créer un livre</h2>
+        <form onSubmit={createBook} className="space-y-2">
+          <input
+            className="w-full p-2 rounded bg-gray-800"
+            value={bookTitle}
+            onChange={(e) => setBookTitle(e.target.value)}
+            placeholder="Titre du livre"
+          />
+          <input
+            className="w-full p-2 rounded bg-gray-800"
+            value={bookAuthor}
+            onChange={(e) => setBookAuthor(e.target.value)}
+            placeholder="Auteur"
+          />
+          <button className="px-4 py-2 bg-green-600 rounded" type="submit">
+            Sauvegarder le livre
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/CreateResources.jsx
+++ b/src/pages/CreateResources.jsx
@@ -37,7 +37,6 @@ export default function CreateResources() {
       setSpells(data || []);
     }
   };
-
   useEffect(() => {
     dbg('Checking session for CreateResources page');
     supabase.auth.getSession().then(({ data: { session } }) => {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -34,6 +34,10 @@ export default function Home() {
     dbg('navigate("/create-character")');
     navigate('/create-character');
   };
+  const goToSpells = () => {
+    dbg('navigate("/spells")');
+    navigate('/spells');
+  };
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState(null);
   const [profile, setProfile] = useState({ is_verified: false, is_mj: false });
@@ -285,6 +289,9 @@ export default function Home() {
       ) : (
         <p className="mt-4">Votre compte est en attente de validation par le MJ.</p>
       )}
+      <button onClick={goToSpells} className="mt-4 px-4 py-2 bg-purple-600 rounded">
+        Liste des sorts
+      </button>
     </div>
   );
 }

--- a/src/pages/MJ.jsx
+++ b/src/pages/MJ.jsx
@@ -12,6 +12,10 @@ const err = (...args) => console.error('[MJ]', ...args);
 export default function MJ() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
+  const [actions, setActions] = useState([]);
+  const [timeline, setTimeline] = useState([]);
+  const [agenda, setAgenda] = useState([]);
+  const [quests, setQuests] = useState([]);
 
   useEffect(() => {
     dbg('Checking session for MJ page');
@@ -42,12 +46,134 @@ export default function MJ() {
     });
   }, [navigate]);
 
+  // Récupération des données asynchrones (actions, timeline, agenda, quêtes)
+  useEffect(() => {
+    if (!loading) {
+      dbg('Chargement des données MJ');
+      const loadData = async () => {
+        try {
+          const { data: act, error: actErr } = await supabase
+            .from('actions')
+            .select('*')
+            .order('created_at');
+          if (actErr) err('actions error', actErr);
+          setActions(act || []);
+
+          const { data: time, error: timeErr } = await supabase
+            .from('timeline')
+            .select('*')
+            .order('position');
+          if (timeErr) err('timeline error', timeErr);
+          setTimeline(time || []);
+
+          const { data: ag, error: agErr } = await supabase
+            .from('agenda')
+            .select('*')
+            .order('date');
+          if (agErr) err('agenda error', agErr);
+          setAgenda(ag || []);
+
+          const { data: qs, error: qsErr } = await supabase
+            .from('quests')
+            .select('*')
+            .order('created_at');
+          if (qsErr) err('quests error', qsErr);
+          setQuests(qs || []);
+        } catch (e) {
+          err('loadData exception', e);
+        }
+      };
+      loadData();
+    }
+  }, [loading]);
+
+  const skipPlayer = (name) => {
+    info('Passer le tour de', name);
+    setTimeline((prev) =>
+      prev.map((t) => (t.player === name ? { ...t, status: 'passé' } : t))
+    );
+  };
+
+  const remindPlayer = (name) => {
+    info('Relance du joueur', name);
+    // Intégration de notifications à prévoir (Discord/email)
+  };
+
   if (loading) return <p>Chargement du dashboard MJ…</p>;
 
   return (
-    <div>
-      <h1>Tableau de bord MJ</h1>
-      {/* …contenu MJ… */}
+    <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
+      <h1 className="text-2xl font-bold mb-4">Tableau de bord MJ</h1>
+      <button
+        onClick={() => navigate('/create-resources')}
+        className="mb-6 px-4 py-2 bg-green-600 rounded"
+      >
+        Gérer les ressources (sorts &amp; livres)
+      </button>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Progression de la partie</h2>
+        {actions.length === 0 ? (
+          <p>Aucune action en attente.</p>
+        ) : (
+          <ul className="space-y-1">
+            {actions.map((a) => (
+              <li key={a.id} className="bg-gray-800 p-2 rounded">
+                <span className="font-medium">{a.player}</span> : {a.description} ({a.status})
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Timeline</h2>
+        <ul className="space-y-1">
+          {timeline.map((t, i) => (
+            <li key={i} className="flex items-center justify-between bg-gray-800 p-2 rounded">
+              <span>
+                {t.player} - {t.status}
+              </span>
+              <div className="space-x-2">
+                <button
+                  onClick={() => skipPlayer(t.player)}
+                  className="px-2 py-1 bg-red-600 rounded text-sm"
+                >
+                  Passer
+                </button>
+                <button
+                  onClick={() => remindPlayer(t.player)}
+                  className="px-2 py-1 bg-blue-600 rounded text-sm"
+                >
+                  Relancer
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Agenda</h2>
+        <ul className="space-y-1">
+          {agenda.map((evt) => (
+            <li key={evt.id} className="bg-gray-800 p-2 rounded">
+              {evt.date} – {evt.title}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Quêtes</h2>
+        <ul className="space-y-1">
+          {quests.map((q) => (
+            <li key={q.id} className="bg-gray-800 p-2 rounded">
+              {q.title} – {q.status}
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/src/pages/Spells.jsx
+++ b/src/pages/Spells.jsx
@@ -1,0 +1,60 @@
+// src/pages/Spells.jsx
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+
+const DEBUG = import.meta.env.VITE_DEBUG === 'true';
+const dbg = (...args) => DEBUG && console.debug('[Spells]', ...args);
+const info = (...args) => console.info('[Spells]', ...args);
+const warn = (...args) => console.warn('[Spells]', ...args);
+const err = (...args) => console.error('[Spells]', ...args);
+
+export default function Spells() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [spells, setSpells] = useState([]);
+
+  useEffect(() => {
+    dbg('Checking session for Spells page');
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (!session?.user) {
+        info('Pas de session, redirection /');
+        navigate('/', { replace: true });
+        return;
+      }
+      try {
+        const { data, error } = await supabase
+          .from('spells')
+          .select('*')
+          .order('name');
+        if (error) {
+          err('fetch spells error', error);
+        }
+        setSpells(data || []);
+      } catch (e) {
+        err('exception fetching spells', e);
+      } finally {
+        setLoading(false);
+      }
+    });
+  }, [navigate]);
+
+  if (loading) return <p>Chargement des sorts...</p>;
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 p-4">
+      <h1 className="text-2xl font-bold mb-4">Liste des sorts</h1>
+      <ul className="space-y-2">
+        {spells.map((s) => (
+          <li key={s.id} className="bg-gray-800 p-2 rounded">
+            <div className="font-semibold">{s.name}</div>
+            <div className="text-sm">{s.description}</div>
+            <div className="text-sm">
+              Niveau {s.level} – {s.school}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Spells` page fetching spells from Supabase
- link to spells list from home page
- register the page in the router

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68416bccf0b883289dd05b205c85f7ac