### PR TITLE
Add comprehensive test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -20,6 +21,11 @@
     "postcss": "^8.4.14",
     "autoprefixer": "^10.4.7",
     "eslint": "^8.24.0",
-    "eslint-plugin-react": "^7.31.10"
+    "eslint-plugin-react": "^7.31.10",
+    "vitest": "^1.0.0",
+    "jsdom": "^22.1.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/pages/Character.jsx
+++ b/src/pages/Character.jsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { computeSkills } from '../utils/skills';
 
 const DEBUG = import.meta.env.VITE_DEBUG === 'true';
 const dbg = (...args) => DEBUG && console.debug('[Character]', ...args);
@@ -16,24 +17,7 @@ export default function CharacterPage() {
   const [loading, setLoading] = useState(true);
   const [character, setCharacter] = useState(null);
 
-  const skills = useMemo(() => {
-    if (!character) return null;
-    const avg = (a, b) => Math.round((a + b) / 2);
-    return {
-      bluff: avg(character.esprit, character.coeur),
-      farce: avg(character.esprit, character.coeur),
-      tactique: avg(character.esprit, character.coeur),
-      rumeur: avg(character.esprit, character.coeur),
-      decorum: avg(character.coeur, character.corps),
-      discretion: avg(character.coeur, character.corps),
-      persuasion: avg(character.coeur, character.corps),
-      romance: avg(character.coeur, character.corps),
-      bagarre: avg(character.corps, character.esprit),
-      endurance: avg(character.corps, character.esprit),
-      perception: avg(character.corps, character.esprit),
-      precision: avg(character.corps, character.esprit),
-    };
-  }, [character]);
+  const skills = useMemo(() => computeSkills(character), [character]);
 
   useEffect(() => {
     dbg('Checking session for Character page');

--- a/src/utils/skills.js
+++ b/src/utils/skills.js
@@ -1,0 +1,18 @@
+export function computeSkills(character) {
+  if (!character) return null;
+  const avg = (a, b) => Math.round((a + b) / 2);
+  return {
+    bluff: avg(character.esprit, character.coeur),
+    farce: avg(character.esprit, character.coeur),
+    tactique: avg(character.esprit, character.coeur),
+    rumeur: avg(character.esprit, character.coeur),
+    decorum: avg(character.coeur, character.corps),
+    discretion: avg(character.coeur, character.corps),
+    persuasion: avg(character.coeur, character.corps),
+    romance: avg(character.coeur, character.corps),
+    bagarre: avg(character.corps, character.esprit),
+    endurance: avg(character.corps, character.esprit),
+    perception: avg(character.corps, character.esprit),
+    precision: avg(character.corps, character.esprit),
+  };
+}

--- a/test/Character.test.js
+++ b/test/Character.test.js
@@ -1,0 +1,23 @@
+import { computeSkills } from '../src/utils/skills';
+
+describe('computeSkills', () => {
+  it('calculates averages correctly', () => {
+    const character = { esprit: 4, coeur: 6, corps: 8 };
+    const skills = computeSkills(character);
+    expect(skills.bluff).toBe(5); // avg(4,6)
+    expect(skills.decorum).toBe(7); // avg(6,8)
+    expect(skills.bagarre).toBe(6); // avg(8,4)
+  });
+
+  it('returns null when character is null', () => {
+    expect(computeSkills(null)).toBeNull();
+  });
+
+  it('rounds values when averaging', () => {
+    const character = { esprit: 5, coeur: 4, corps: 7 };
+    const skills = computeSkills(character);
+    // avg(5,4) = 4.5 -> 5
+    expect(skills.bluff).toBe(5);
+    expect(skills.decorum).toBe(6); // avg(4,7) -> 5.5 -> 6
+  });
+});

--- a/test/CharacterPage.test.jsx
+++ b/test/CharacterPage.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import CharacterPage from '../src/pages/Character.jsx';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { user: { id: '1' } } } }),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: '1',
+          user_id: '1',
+          nom: 'Harry',
+          esprit: 5,
+          coeur: 5,
+          corps: 5,
+          magie: 5,
+          dortoir: 'fille',
+          maison: 'gryffondor',
+          ascendance: 'n/a',
+          annee: 1,
+        },
+      }),
+    })),
+  },
+}));
+
+describe('CharacterPage', () => {
+  it('displays character data and skills', async () => {
+    render(
+      <MemoryRouter initialEntries={['/character/1']}>
+        <Routes>
+          <Route path="/character/:id" element={<CharacterPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Harry')).toBeInTheDocument();
+    expect(screen.getByText('Bluff : 5')).toBeInTheDocument();
+  });
+});

--- a/test/CreateCharacter.test.jsx
+++ b/test/CreateCharacter.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import CreateCharacter from '../src/pages/CreateCharacter.jsx';
+import { supabase } from '../src/supabaseClient';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+describe('CreateCharacter page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to manage page when character already exists', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/create-character']}>
+        <Routes>
+          <Route path="/create-character" element={<CreateCharacter />} />
+          <Route path="/manage-character" element={<p>Manage</p>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Manage')).toBeInTheDocument();
+  });
+});

--- a/test/CreateResources.test.jsx
+++ b/test/CreateResources.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import CreateResources from '../src/pages/CreateResources.jsx';
+import { supabase } from '../src/supabaseClient';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+describe('CreateResources page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when user is MJ', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockImplementation((table) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(
+        table === 'profiles' ? { data: { is_mj: true } } : { data: [] }
+      ),
+      order: vi.fn().mockResolvedValue({ data: [] }),
+      insert: vi.fn().mockResolvedValue({}),
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/create-resources']}>
+        <Routes>
+          <Route path="/create-resources" element={<CreateResources />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Gestion des ressources')).toBeInTheDocument();
+  });
+});

--- a/test/Game.test.jsx
+++ b/test/Game.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import Game from '../src/pages/Game.jsx';
+import { supabase } from '../src/supabaseClient';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+describe('Game page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to create character when none exists', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/game']}>
+        <Routes>
+          <Route path="/" element={<p>HOME</p>} />
+          <Route path="/create-character" element={<p>CREATE</p>} />
+          <Route path="/game" element={<Game />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('CREATE')).toBeInTheDocument();
+  });
+
+  it('shows game when character exists', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/game']}>
+        <Routes>
+          <Route path="/game" element={<Game />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Bienvenue dans le jeu')).toBeInTheDocument();
+  });
+});

--- a/test/Home.test.jsx
+++ b/test/Home.test.jsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../src/pages/Home';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      exchangeCodeForSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      signInWithOAuth: vi.fn()
+    },
+    from: vi.fn(() => ({
+      upsert: vi.fn().mockResolvedValue({ data: null }),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null })
+    }))
+  }
+}));
+
+describe('Home', () => {
+  it('shows login when not authenticated', async () => {
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Se connecter avec Discord')).toBeInTheDocument();
+  });
+
+  it('shows dashboard when user session exists', async () => {
+    const user = { id: '1', user_metadata: { login: 'testuser' }, email: 'test@example.com' };
+    const getSession = vi.fn().mockResolvedValue({ data: { session: { user } } });
+    const mod = await import('../src/supabaseClient');
+    mod.supabase.auth.getSession = getSession;
+    mod.supabase.from = vi.fn(() => ({
+      upsert: vi.fn().mockResolvedValue({ data: null }),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { is_verified: true, is_mj: false } }),
+    }));
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText(/Bonjour/)).toBeInTheDocument();
+  });
+
+  it('shows MJ dashboard link when user is MJ', async () => {
+    const user = { id: '2', user_metadata: { login: 'mj' }, email: 'mj@example.com' };
+    const mod = await import('../src/supabaseClient');
+    mod.supabase.auth.getSession = vi.fn().mockResolvedValue({ data: { session: { user } } });
+    mod.supabase.from = vi.fn((table) => ({
+      upsert: vi.fn().mockResolvedValue({ data: null }),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(
+        table === 'profiles'
+          ? { data: { is_verified: true, is_mj: true } }
+          : { data: [] }
+      )
+    }));
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Tableau de bord MJ')).toBeInTheDocument();
+  });
+
+  it('prompts to create character when verified user has none', async () => {
+    const user = { id: '3', user_metadata: { login: 'newuser' }, email: 'n@example.com' };
+    const mod = await import('../src/supabaseClient');
+    mod.supabase.auth.getSession = vi.fn().mockResolvedValue({ data: { session: { user } } });
+    mod.supabase.from = vi.fn((table) => ({
+      upsert: vi.fn().mockResolvedValue({ data: null }),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(
+        table === 'profiles'
+          ? { data: { is_verified: true, is_mj: false } }
+          : { data: [] }
+      )
+    }));
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Créer mon personnage')).toBeInTheDocument();
+  });
+});

--- a/test/HouseWheel.test.jsx
+++ b/test/HouseWheel.test.jsx
@@ -1,0 +1,18 @@
+import { render, fireEvent } from '@testing-library/react';
+import HouseWheel from '../src/components/HouseWheel';
+
+describe('HouseWheel', () => {
+  it('renders four houses', () => {
+    const { container } = render(<HouseWheel value="" onChange={() => {}} />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(4);
+  });
+
+  it('calls onChange when a house is clicked', () => {
+    const handle = vi.fn();
+    const { container } = render(<HouseWheel value="" onChange={handle} />);
+    const paths = container.querySelectorAll('path');
+    fireEvent.click(paths[0]);
+    expect(handle).toHaveBeenCalledWith('gryffondor');
+  });
+});

--- a/test/MJ.test.jsx
+++ b/test/MJ.test.jsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import MJ from '../src/pages/MJ.jsx';
+import { supabase } from '../src/supabaseClient';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+describe('MJ page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects non-MJ users to home', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockImplementation((table) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(
+        table === 'profiles' ? { data: { is_mj: false } } : { data: [] }
+      ),
+      order: vi.fn().mockResolvedValue({ data: [] }),
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/mj']}>
+        <Routes>
+          <Route path="/" element={<p>HOME</p>} />
+          <Route path="/mj" element={<MJ />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('HOME')).toBeInTheDocument();
+  });
+
+  it('shows dashboard for MJ users', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockImplementation((table) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(
+        table === 'profiles' ? { data: { is_mj: true } } : { data: [] }
+      ),
+      order: vi.fn().mockResolvedValue({ data: [] }),
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/mj']}>
+        <Routes>
+          <Route path="/mj" element={<MJ />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Tableau de bord MJ')).toBeInTheDocument();
+  });
+});

--- a/test/ManageCharacter.test.jsx
+++ b/test/ManageCharacter.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import ManageCharacter from '../src/pages/ManageCharacter.jsx';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+
+const character = { id: 1, nom: 'Harry' };
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { user: { id: '1' } } } }),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: character })
+    }))
+  }
+}));
+
+describe('ManageCharacter', () => {
+  it('renders character name after load', async () => {
+    render(
+      <MemoryRouter>
+        <ManageCharacter />
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Gestion du personnage')).toBeInTheDocument();
+    expect(screen.getByText('Harry')).toBeInTheDocument();
+  });
+
+  it('redirects to create page when no character', async () => {
+    const mod = await import('../src/supabaseClient');
+    mod.supabase.from = vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null })
+    }));
+
+    render(
+      <MemoryRouter initialEntries={['/manage-character']}> 
+        <Routes>
+          <Route path="/manage-character" element={<ManageCharacter />} />
+          <Route path="/create-character" element={<p>Create</p>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Create')).toBeInTheDocument();
+  });
+});

--- a/test/Spells.test.jsx
+++ b/test/Spells.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+import Spells from '../src/pages/Spells.jsx';
+import { supabase } from '../src/supabaseClient';
+
+vi.mock('../src/supabaseClient', () => ({
+  supabase: {
+    auth: { getSession: vi.fn() },
+    from: vi.fn(),
+  },
+}));
+
+describe('Spells page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows list of spells', async () => {
+    supabase.auth.getSession.mockResolvedValue({ data: { session: { user: { id: '1' } } } });
+    supabase.from.mockImplementation(() => {
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [
+          { id: 1, name: 'Accio', description: 'Call object', level: 1, school: 'Charms' }
+        ] }),
+      };
+      return chain;
+    });
+    render(
+      <MemoryRouter initialEntries={['/spells']}>
+        <Routes>
+          <Route path="/spells" element={<Spells />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('Accio')).toBeInTheDocument();
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom';
+// React plugin preamble workaround for vitest
+globalThis.__vite_plugin_react_preamble_installed__ = true;

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,5 +6,10 @@ export default defineConfig({
   plugins: [react()],
   server: {
     open: true
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './test/setup.js'
   }
 });


### PR DESCRIPTION
## Summary
- expand home page tests for MJ role and character creation prompt
- cover skills rounding logic
- add tests for character details, game flow, MJ dashboard, spells list
- test character creation and resource management pages
- ensure redirect logic in ManageCharacter

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_68433ebf336083289c3d813c23972920